### PR TITLE
freeze tokenizers dependency to 0.13.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tokenizers = "=0.13.3"
 async-stream = "0.3.5"
 axum = "0.6.19"
 clap = { version = "4.3.19", features = ["derive"] }


### PR DESCRIPTION
Froze tokenizers dep to v0.13.3 to prevent build error on decode signature which change in v0.13.4
Build errors are coming from tokenizers -> llm-base -> cria : 
```
error[E0308]: mismatched types
   --> llm/crates/llm-base/src/tokenizer/huggingface.rs:25:21
    |
25  |             .decode(vec![idx as u32], true)
    |              ------ ^^^^^^^^^^^^^^^^ expected `&[u32]`, found `Vec<u32>`
    |              |
    |              arguments to this method are incorrect
    |
    = note: expected reference `&[u32]`
                  found struct `Vec<u32>`
```
