### PR TITLE
Revert "freeze tokenizers dependency to 0.13.3"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokenizers = "=0.13.3"
 async-stream = "0.3.5"
 axum = "0.6.19"
 clap = { version = "4.3.19", features = ["derive"] }


### PR DESCRIPTION
Reverts AmineDiro/cria#9