### PR TITLE
Single model with requests queue

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.env
+target/
+python/
+tests/
+docker/
+Dockerfile
+content/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ llm = { git = "https://github.com/rustformers/llm.git", rev = "2f6ffd4435799ceaa
 llm-llama = "0.1.1"
 rand = "0.8.5"
 serde = { version = "1.0.179", features = ["derive"] }
-tokio = { version = "1.29.1", features = ["full"] }
+tokio = { version = "1.29.1", features = ["full", "rt"] }
 tokio-stream = "0.1.14"
 tower-http = { version = "0.4.0", features = ["trace"] }
 uuid = { version = "1.4.1", features = ["v4"] }
@@ -34,6 +34,7 @@ opentelemetry-zipkin = { version = "0.18.0", features = [
 axum-tracing-opentelemetry = "0.13.1"
 axum-prometheus = "0.4.0"
 figment = { version = "0.10.10", features = ["env"] }
+flume = "0.11.0"
 
 [profile.dev.package.ggml-sys]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ axum-tracing-opentelemetry = "0.13.1"
 axum-prometheus = "0.4.0"
 figment = { version = "0.10.10", features = ["env"] }
 flume = "0.11.0"
+serde_json = "1.0.105"
 
 [profile.dev.package.ggml-sys]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -192,12 +192,16 @@ You can clearly see generation using my M1 GPU:
 - [x] Setup good tracing
 - [x] Docker deployment on CPUs / GPU
 - [x] Metrics : Prometheus
-- [ ] Better errors
+- [x] Implement a global request queue
+  - [x] For each response put an entry in a queue
+  - [x] Spawn a model in separate task reading from ringbuffer, get entry and put each token in response
+  - [x] Construct stream from flume resp_rx chan and stream responses to user.
+- [ ] BETTER ERRORS and http responses (deal with all the unwrapping)
 - [ ] Implement streaming chat completions SSE
-- [ ] Batching requests(ala iouring):
-  - For each response put an entry in a ringbuffer queue with : Entry(Flume mpsc (resp_rx,resp_tx))
-  - Spawn a model in separate task reading from ringbuffer, get entry and put each token in response
-  - Construct stream from flue resp_rx chan and return SSE(stream) to user.
+- [ ] Implement request batching
+- [ ] Implement request continuous batching
+- [ ] Setup CI/CD
+- [ ] _Maybe_ Support huggingface `candle` lib for a full rust integration
 
 ## API routes
 

--- a/python/bench/llama-cpp.py
+++ b/python/bench/llama-cpp.py
@@ -1,0 +1,20 @@
+import time
+
+from llama_cpp import Llama
+
+llm = Llama(
+    model_path="/media/amine/models/llama/llama-2-13b.ggmlv3.q4_K_M.bin",
+    n_gpu_layers=32,
+    n_ctx=200,
+    verbose=False,
+)
+
+s = time.perf_counter()
+output = llm(
+    "Q: Name the planets in the solar system? A: ",
+    max_tokens=30,
+    # stop=["Q:", "\n"],
+    echo=True,
+)
+e = time.perf_counter()
+print(f"Generation took {e-s:.2f}s")

--- a/python/bench/parallel_chat.py
+++ b/python/bench/parallel_chat.py
@@ -1,0 +1,33 @@
+from concurrent.futures import ProcessPoolExecutor
+
+import openai
+
+openai.organization = "YOUR_ORG_ID"
+openai.api_key = "test"
+openai.api_base = "http://localhost:3000/v1"
+
+
+def chat_request(idx):
+    completion = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Who won the world series in 2020?"},
+            {
+                "role": "assistant",
+                "content": "The Los Angeles Dodgers won the World Series in 2020.",
+            },
+            {"role": "user", "content": "Where was it played?"},
+        ],
+    )
+    return idx, completion.choices[0].message
+
+
+if __name__ == "__main__":
+    with ProcessPoolExecutor(5) as e:
+        result = e.map(chat_request, range(3))
+
+    print(list(result))
+
+    # for p in prompts:
+    #     sse_request(p)

--- a/python/bench/parallel_embedding.py
+++ b/python/bench/parallel_embedding.py
@@ -1,0 +1,29 @@
+from concurrent.futures import ProcessPoolExecutor
+
+import openai
+
+openai.organization = "YOUR_ORG_ID"
+openai.api_key = "test"
+openai.api_base = "http://localhost:3000/v1"
+
+
+def embed_req(text):
+    response = openai.Embedding.create(input=text, model="llama-2")
+    return response["data"][0]["embedding"]
+
+
+if __name__ == "__main__":
+    text = [
+        "You are a helpful assistant.",
+        # "Who won the world series in 2020?",
+        # "The Los Angeles Dodgers won the World Series in 2020.",
+        # "Where was it played?",
+    ]
+
+    with ProcessPoolExecutor(5) as e:
+        result = e.map(embed_req, text)
+
+    print(list(result))
+
+    # for p in prompts:
+    #     sse_request(p)

--- a/python/bench/parallel_sse_client.py
+++ b/python/bench/parallel_sse_client.py
@@ -7,17 +7,15 @@ from concurrent.futures import ProcessPoolExecutor
 import sseclient
 import urllib3
 
-url = "http://localhost:3000/v1/completions_stream"
+url = "http://localhost:3000/v1/completions"
 
 
 def sse_request(prompt: str):
     http = urllib3.PoolManager()
-
     response = http.request(
         "POST",
         url,
         preload_content=False,
-        # headers={"Accept": "text/event-stream"},
         headers={
             "Content-Type": "application/json",
         },
@@ -25,7 +23,7 @@ def sse_request(prompt: str):
             {
                 "prompt": prompt,
                 "temperature": 0.8,
-                "max_tokens": 256,
+                "max_tokens": 10,
                 "stream": True,
             }
         ),
@@ -34,28 +32,25 @@ def sse_request(prompt: str):
     client = sseclient.SSEClient(response)
 
     s = time.perf_counter()
-    txt = ""
+    resp = ""
     for event in client.events():
         chunk = json.loads(event.data)
-        txt += chunk["choices"][0]["text"]
         sys.stdout.write(chunk["choices"][0]["text"])
         sys.stdout.flush()
+        resp += chunk["choices"][0]["text"]
     e = time.perf_counter()
-
-    print(
-        f"\n [{os.getpid()}] Generation from completion took {e-s:.2f} !\
-            Result : {txt}"
-    )
+    print(f"{[os.getpid()]}\nGeneration from completion took {e-s:.2f}!")
 
 
 if __name__ == "__main__":
     prompts = [
         "Morocco is a beautiful country",
-        "Engineering is ",
-        "Soccer is a best ",
+        "Soccer is a beautiful sport because",
+        "Engineering is an amazing job ",
     ]
+
+    with ProcessPoolExecutor(5) as e:
+        e.map(sse_request, prompts)
+
     # for p in prompts:
     #     sse_request(p)
-
-    with ProcessPoolExecutor(4) as e:
-        e.map(sse_request, prompts)

--- a/python/llamaindex_completion_stream.py
+++ b/python/llamaindex_completion_stream.py
@@ -1,0 +1,18 @@
+import os
+
+import openai
+from llama_index.llms import OpenAI
+
+openai.organization = "YOUR_ORG_ID"
+openai.api_key = "EMPTY"
+openai.api_base = "http://localhost:3000/v1"
+
+
+# non-streaming
+llm = OpenAI()
+resp = llm.complete("Paul Graham is ")
+print(resp)
+
+# resp = llm.stream_complete("Paul Graham is ")
+# for delta in resp:
+#     print(delta, end="")

--- a/python/openai_chat_completion.py
+++ b/python/openai_chat_completion.py
@@ -7,6 +7,7 @@ openai.api_base = "http://localhost:3000/v1"
 
 completion = openai.ChatCompletion.create(
     model="gpt-3.5-turbo",
+    max_tokens=512,
     messages=[
         {"role": "system", "content": "You are a helpful assistant."},
         {

--- a/python/openai_chat_completion.py
+++ b/python/openai_chat_completion.py
@@ -9,7 +9,10 @@ completion = openai.ChatCompletion.create(
     model="gpt-3.5-turbo",
     messages=[
         {"role": "system", "content": "You are a helpful assistant."},
-        {"role": "user", "content": "Hello!"},
+        {
+            "role": "user",
+            "content": "Hello! Can you give informations about morocco ? ",
+        },
     ],
 )
 

--- a/python/openai_completion.py
+++ b/python/openai_completion.py
@@ -5,6 +5,7 @@ import openai
 openai.organization = "YOUR_ORG_ID"
 openai.api_key = "test"
 openai.api_base = "http://localhost:3000/v1"
+
 pprint.pprint(openai.Model.list())
 
 result = openai.Completion.create(

--- a/python/openai_completion_stream.py
+++ b/python/openai_completion_stream.py
@@ -1,16 +1,17 @@
-import pprint
+from sys import stdout
 
 import openai
 
 openai.organization = "YOUR_ORG_ID"
 openai.api_key = "test"
 openai.api_base = "http://localhost:3000/v1"
-pprint.pprint(openai.Model.list())
 
-result = openai.Completion.create(
+response = openai.Completion.create(
     model="llama-2",
-    prompt="This is a story of a hero.",
+    prompt="This is a story of a hero who went",
     stream=True,
 )
-for chunk in result:
-    print(chunk)
+for event in response:
+    event_text = event["choices"][0]["text"]  # extract the text
+    stdout.write(event_text)
+    stdout.flush()

--- a/python/openai_embeddings.py
+++ b/python/openai_embeddings.py
@@ -12,4 +12,5 @@ def get_embedding(text: str, model="text-embedding-ada-002") -> list[float]:
 
 
 embedding = get_embedding("Your text goes here", model="llama-2")
+print(embedding)
 print(len(embedding))

--- a/python/parallel_sse_client.py
+++ b/python/parallel_sse_client.py
@@ -1,0 +1,58 @@
+import json
+import os
+import time
+from concurrent.futures import ProcessPoolExecutor
+
+import sseclient
+import urllib3
+
+url = "http://localhost:3000/v1/completions_stream"
+
+
+def sse_request(prompt: str):
+    http = urllib3.PoolManager()
+
+    response = http.request(
+        "POST",
+        url,
+        preload_content=False,
+        # headers={"Accept": "text/event-stream"},
+        headers={
+            "Content-Type": "application/json",
+        },
+        body=json.dumps(
+            {
+                "prompt": prompt,
+                "temperature": 0.8,
+                "max_tokens": 100,
+                "stream": True,
+            }
+        ),
+    )
+
+    client = sseclient.SSEClient(response)
+
+    s = time.perf_counter()
+    txt = ""
+    for event in client.events():
+        chunk = json.loads(event.data)
+        txt += chunk["choices"][0]["text"]
+    e = time.perf_counter()
+
+    print(
+        f"\n [{os.getpid()}] Generation from completion took {e-s:.2f} !\
+            Result : {txt}"
+    )
+
+
+if __name__ == "__main__":
+    prompts = [
+        "Morocco is a beautiful country",
+        "Engineering is ",
+        "Soccer is a best ",
+    ]
+    # for p in prompts:
+    #     sse_request(p)
+
+    with ProcessPoolExecutor(4) as e:
+        e.map(sse_request, prompts)

--- a/python/sse_client.py
+++ b/python/sse_client.py
@@ -5,7 +5,7 @@ import time
 import sseclient
 import urllib3
 
-url = "http://localhost:3000/v1/completions_stream"
+url = "http://localhost:3000/v1/completions"
 
 
 http = urllib3.PoolManager()
@@ -21,7 +21,7 @@ response = http.request(
         {
             "prompt": "Morocco is a beautiful country",
             "temperature": 0.8,
-            "max_tokens": 100,
+            "max_tokens": 256,
             "stream": True,
         }
     ),
@@ -30,8 +30,10 @@ response = http.request(
 client = sseclient.SSEClient(response)
 
 s = time.perf_counter()
+
 for event in client.events():
     chunk = json.loads(event.data)
+
     sys.stdout.write(chunk["choices"][0]["text"])
     sys.stdout.flush()
 e = time.perf_counter()

--- a/python/sse_client.py
+++ b/python/sse_client.py
@@ -5,7 +5,7 @@ import time
 import sseclient
 import urllib3
 
-url = "http://localhost:3000/v1/completions"
+url = "http://localhost:3000/v1/completions_stream"
 
 
 http = urllib3.PoolManager()

--- a/src/inferer.rs
+++ b/src/inferer.rs
@@ -166,7 +166,7 @@ impl RequestQueue {
     pub(crate) fn new(queue: Sender<InferenceEvent>) -> Self {
         Self { queue }
     }
-    pub(crate) async fn append(&mut self, event: InferenceEvent) {
+    pub(crate) async fn push(&mut self, event: InferenceEvent) {
         // TODO: deal with result
         self.queue.send_async(event).await.unwrap_or_else(|err| {
             panic!(
@@ -175,8 +175,4 @@ impl RequestQueue {
             )
         })
     }
-    // fn generate_completion_stream() {}
-    // fn generate_chat_stream() {}
-    // fn generate_completion(&mut self) {}
-    // fn generate_chat() {}
 }

--- a/src/inferer.rs
+++ b/src/inferer.rs
@@ -139,7 +139,9 @@ pub fn inference_loop(model: Box<dyn Model>, rx_queue: Receiver<InferenceEvent>)
             InferenceEvent::EmbeddingEvent(request, request_tx) => {
                 stream_embedding(&model, request, request_tx)
             }
-            InferenceEvent::_ChatEvent => {}
+            InferenceEvent::_ChatEvent => {
+                todo!()
+            }
         }
     }
 }
@@ -156,7 +158,7 @@ pub enum InferenceEvent {
     _ChatEvent,
 }
 
-/// Requester holding
+/// Multi producer sender queue to put requests
 #[derive(Clone)]
 pub struct RequestQueue {
     queue: Sender<InferenceEvent>,

--- a/src/inferer.rs
+++ b/src/inferer.rs
@@ -8,6 +8,9 @@ use llm::TokenUtf8Buffer;
 use llm::Tokenizer;
 use llm::{feed_prompt_callback, InferenceError, InferenceFeedback};
 
+use crate::routes::chat::chat_completion;
+use crate::routes::chat::ChatCompletionRequest;
+use crate::routes::chat::ChatCompletionResponse;
 use crate::routes::completions::CompletionRequest;
 use crate::routes::embeddings::Embedding;
 use crate::routes::embeddings::EmbeddingRequest;
@@ -145,8 +148,8 @@ pub fn inference_loop(model: Box<dyn Model>, rx_queue: Receiver<InferenceEvent>)
             InferenceEvent::EmbeddingEvent(request, request_tx) => {
                 stream_embedding(&model, request, request_tx)
             }
-            InferenceEvent::_ChatEvent => {
-                todo!()
+            InferenceEvent::ChatEvent(request, request_tx) => {
+                chat_completion(&model, request, request_tx)
             }
         }
     }
@@ -161,7 +164,10 @@ pub enum InferenceEvent {
         Sender<Result<StreamingResponse, InferenceError>>,
     ),
     EmbeddingEvent(EmbeddingRequest, Sender<Result<Embedding, InferenceError>>),
-    _ChatEvent,
+    ChatEvent(
+        ChatCompletionRequest,
+        Sender<Result<ChatCompletionResponse, InferenceError>>,
+    ),
 }
 
 /// Multi producer sender queue to put requests

--- a/src/inferer.rs
+++ b/src/inferer.rs
@@ -1,0 +1,131 @@
+use std::time::Duration;
+
+use flume::{Receiver, Sender};
+use llm::samplers::build_sampler;
+use llm::Model;
+use llm::TokenUtf8Buffer;
+use llm::{feed_prompt_callback, InferenceError, InferenceFeedback};
+
+use crate::routes::completions::CompletionRequest;
+
+pub fn run_inference(model: Box<dyn Model>, rx_queue: Receiver<InferenceEvent>) {
+    // runs loop to get event and do inference
+    tracing::info!("Running model inference !");
+    while let Ok(inference_request) = rx_queue.recv() {
+        match inference_request {
+            InferenceEvent::CompletionEvent(request, request_tx) => {
+                let mut session: llm::InferenceSession = model.start_session(Default::default());
+                let prompt = request.prompt.into_iter().collect::<String>();
+
+                let mut response_tokens: Vec<String> = Vec::new();
+
+                let maximum_token_count = request.max_tokens.min(usize::MAX);
+                let repetition_penalty_last_n = 512;
+                let sampler_args = vec![
+                    format!("topk:k={}", request.top_k),
+                    format!("topp:p={}", request.top_p),
+                    format!(
+                        "repetition:penalty={}:last_n={}",
+                        request.repeat_penalty, repetition_penalty_last_n
+                    ),
+                    format!("temperature:temperature={}", request.temperature),
+                ];
+                let sampler = build_sampler(0, &[], &sampler_args).unwrap();
+                // First push the prompt to the model
+                if !prompt.is_empty() {
+                    session
+                        .feed_prompt(
+                            model.as_ref(),
+                            llm::Prompt::Text(&prompt),
+                            &mut Default::default(),
+                            feed_prompt_callback::<_>(|r| match r {
+                                llm::InferenceResponse::PromptToken(_) => {
+                                    Ok::<InferenceFeedback, InferenceError>(
+                                        llm::InferenceFeedback::Continue,
+                                    )
+                                }
+                                llm::InferenceResponse::InferredToken(t) => {
+                                    let _ = &response_tokens.push(t);
+                                    Ok(llm::InferenceFeedback::Continue)
+                                }
+                                _ => Ok(llm::InferenceFeedback::Continue),
+                            }),
+                        )
+                        .unwrap();
+                }
+                // After the prompt is consumed, sample tokens by repeatedly calling
+                // `infer_next_token`. We generate tokens until the model returns an
+                // EndOfText token, or we run out of space in the context window,
+                // or we reach the specified limit.
+                let mut tokens_processed = 0;
+                let mut token_utf8_buf = TokenUtf8Buffer::new();
+
+                while tokens_processed < maximum_token_count {
+                    let token = match session.infer_next_token(
+                        model.as_ref(),
+                        &llm::InferenceParameters {
+                            sampler: sampler.clone(),
+                        },
+                        &mut Default::default(),
+                        &mut rand::thread_rng(),
+                    ) {
+                        Ok(token) => token,
+                        // TODO: Send an end of stream or end
+                        Err(InferenceError::EndOfText) => break,
+                        // TODO: Handle actual errors
+                        Err(_) => break,
+                    };
+                    tokens_processed += 1;
+
+                    // Buffer the token until it's valid UTF-8
+                    if let Some(token) = token_utf8_buf.push(&token) {
+                        let _res = request_tx
+                            .send_timeout(
+                                Ok(StreamingResponse { token }),
+                                Duration::from_millis(10),
+                            )
+                            .unwrap();
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+pub struct StreamingResponse {
+    pub token: String,
+}
+pub enum InferenceEvent {
+    CompletionEvent(
+        CompletionRequest,
+        Sender<Result<StreamingResponse, InferenceError>>,
+    ),
+    _EmbeddingEvent,
+    _ChatEvent,
+}
+
+/// Requester holding
+#[derive(Clone)]
+pub struct RequestQueue {
+    queue: Sender<InferenceEvent>,
+}
+
+impl RequestQueue {
+    pub(crate) fn new(queue: Sender<InferenceEvent>) -> Self {
+        Self { queue }
+    }
+    pub(crate) async fn append(&mut self, event: InferenceEvent) {
+        // TODO: result
+        self.queue.send_async(event).await.unwrap_or_else(|err| {
+            panic!(
+                "Can't append the event on inference queue. Err {:?}",
+                err.to_string()
+            )
+        })
+    }
+    // fn generate_completion_stream() {}
+    // fn generate_chat_stream() {}
+    // fn generate_completion(&mut self) {}
+    // fn generate_chat() {}
+}

--- a/src/inferer.rs
+++ b/src/inferer.rs
@@ -2,93 +2,140 @@ use std::time::Duration;
 
 use flume::{Receiver, Sender};
 use llm::samplers::build_sampler;
+use llm::InferenceSession;
 use llm::Model;
 use llm::TokenUtf8Buffer;
+use llm::Tokenizer;
 use llm::{feed_prompt_callback, InferenceError, InferenceFeedback};
 
 use crate::routes::completions::CompletionRequest;
+use crate::routes::embeddings::EmbeddingRequest;
 
-pub fn run_inference(model: Box<dyn Model>, rx_queue: Receiver<InferenceEvent>) {
-    // runs loop to get event and do inference
-    tracing::info!("Running model inference !");
+fn stream_completion(
+    model: &Box<dyn Model>,
+    request: CompletionRequest,
+    request_tx: Sender<Result<StreamingResponse, InferenceError>>,
+) {
+    let mut session: llm::InferenceSession = model.start_session(Default::default());
+    let prompt = request.prompt.into_iter().collect::<String>();
+
+    let mut response_tokens: Vec<String> = Vec::new();
+
+    let maximum_token_count = request.max_tokens.min(usize::MAX);
+    let repetition_penalty_last_n = 512;
+    let sampler_args = vec![
+        format!("topk:k={}", request.top_k),
+        format!("topp:p={}", request.top_p),
+        format!(
+            "repetition:penalty={}:last_n={}",
+            request.repeat_penalty, repetition_penalty_last_n
+        ),
+        format!("temperature:temperature={}", request.temperature),
+    ];
+    let sampler = build_sampler(0, &[], &sampler_args).unwrap();
+    // First push the prompt to the model
+    if !prompt.is_empty() {
+        session
+            .feed_prompt(
+                model.as_ref(),
+                llm::Prompt::Text(&prompt),
+                &mut Default::default(),
+                feed_prompt_callback::<_>(|r| match r {
+                    llm::InferenceResponse::PromptToken(_) => {
+                        Ok::<InferenceFeedback, InferenceError>(llm::InferenceFeedback::Continue)
+                    }
+                    llm::InferenceResponse::InferredToken(t) => {
+                        let _ = &response_tokens.push(t);
+                        Ok(llm::InferenceFeedback::Continue)
+                    }
+                    _ => Ok(llm::InferenceFeedback::Continue),
+                }),
+            )
+            .unwrap();
+    }
+    // After the prompt is consumed, sample tokens by repeatedly calling
+    // `infer_next_token`. We generate tokens until the model returns an
+    // EndOfText token, or we run out of space in the context window,
+    // or we reach the specified limit.
+    let mut tokens_processed = 0;
+    let mut token_utf8_buf = TokenUtf8Buffer::new();
+
+    while tokens_processed < maximum_token_count {
+        let token = match session.infer_next_token(
+            model.as_ref(),
+            &llm::InferenceParameters {
+                sampler: sampler.clone(),
+            },
+            &mut Default::default(),
+            &mut rand::thread_rng(),
+        ) {
+            Ok(token) => token,
+            // TODO: Send an end of stream or end
+            Err(InferenceError::EndOfText) => break,
+            // TODO: Handle actual errors
+            Err(_) => break,
+        };
+        tokens_processed += 1;
+
+        // Buffer the token until it's valid UTF-8
+        if let Some(token) = token_utf8_buf.push(&token) {
+            let _res = request_tx
+                .send_timeout(Ok(StreamingResponse { token }), Duration::from_millis(10))
+                .unwrap();
+        }
+    }
+}
+
+fn embed_string(
+    model: &Box<dyn Model>,
+    session: &mut InferenceSession,
+    vocab: &Tokenizer,
+    query: &str,
+) -> (usize, Option<Vec<f32>>) {
+    let mut output_request = llm::OutputRequest {
+        all_logits: None,
+        embeddings: Some(Vec::new()),
+    };
+    let beginning_of_sentence = true;
+    let query_token_ids = vocab
+        .tokenize(query, beginning_of_sentence)
+        .unwrap()
+        .iter()
+        .map(|(_, tok)| *tok)
+        .collect::<Vec<_>>();
+    model.evaluate(&mut *session, &query_token_ids, &mut output_request);
+
+    (query_token_ids.len(), output_request.embeddings)
+}
+
+fn stream_embedding(
+    model: &Box<dyn Model>,
+    request: EmbeddingRequest,
+    request_tx: Sender<Result<(usize, Option<Vec<f32>>), InferenceError>>,
+) {
+    let mut session = model.start_session(Default::default());
+    let vocab = model.tokenizer();
+
+    for input in request.input {
+        let (ntokens, embd) = embed_string(&model, &mut session, &vocab, &input);
+        let _res = request_tx
+            .send_timeout(Ok((ntokens, embd)), Duration::from_millis(10))
+            .unwrap();
+    }
+}
+
+pub fn inference_loop(model: Box<dyn Model>, rx_queue: Receiver<InferenceEvent>) {
+    // Runs inference loop :  match on event and stream inference
+    tracing::info!("Running model inference thread !");
     while let Ok(inference_request) = rx_queue.recv() {
         match inference_request {
             InferenceEvent::CompletionEvent(request, request_tx) => {
-                let mut session: llm::InferenceSession = model.start_session(Default::default());
-                let prompt = request.prompt.into_iter().collect::<String>();
-
-                let mut response_tokens: Vec<String> = Vec::new();
-
-                let maximum_token_count = request.max_tokens.min(usize::MAX);
-                let repetition_penalty_last_n = 512;
-                let sampler_args = vec![
-                    format!("topk:k={}", request.top_k),
-                    format!("topp:p={}", request.top_p),
-                    format!(
-                        "repetition:penalty={}:last_n={}",
-                        request.repeat_penalty, repetition_penalty_last_n
-                    ),
-                    format!("temperature:temperature={}", request.temperature),
-                ];
-                let sampler = build_sampler(0, &[], &sampler_args).unwrap();
-                // First push the prompt to the model
-                if !prompt.is_empty() {
-                    session
-                        .feed_prompt(
-                            model.as_ref(),
-                            llm::Prompt::Text(&prompt),
-                            &mut Default::default(),
-                            feed_prompt_callback::<_>(|r| match r {
-                                llm::InferenceResponse::PromptToken(_) => {
-                                    Ok::<InferenceFeedback, InferenceError>(
-                                        llm::InferenceFeedback::Continue,
-                                    )
-                                }
-                                llm::InferenceResponse::InferredToken(t) => {
-                                    let _ = &response_tokens.push(t);
-                                    Ok(llm::InferenceFeedback::Continue)
-                                }
-                                _ => Ok(llm::InferenceFeedback::Continue),
-                            }),
-                        )
-                        .unwrap();
-                }
-                // After the prompt is consumed, sample tokens by repeatedly calling
-                // `infer_next_token`. We generate tokens until the model returns an
-                // EndOfText token, or we run out of space in the context window,
-                // or we reach the specified limit.
-                let mut tokens_processed = 0;
-                let mut token_utf8_buf = TokenUtf8Buffer::new();
-
-                while tokens_processed < maximum_token_count {
-                    let token = match session.infer_next_token(
-                        model.as_ref(),
-                        &llm::InferenceParameters {
-                            sampler: sampler.clone(),
-                        },
-                        &mut Default::default(),
-                        &mut rand::thread_rng(),
-                    ) {
-                        Ok(token) => token,
-                        // TODO: Send an end of stream or end
-                        Err(InferenceError::EndOfText) => break,
-                        // TODO: Handle actual errors
-                        Err(_) => break,
-                    };
-                    tokens_processed += 1;
-
-                    // Buffer the token until it's valid UTF-8
-                    if let Some(token) = token_utf8_buf.push(&token) {
-                        let _res = request_tx
-                            .send_timeout(
-                                Ok(StreamingResponse { token }),
-                                Duration::from_millis(10),
-                            )
-                            .unwrap();
-                    }
-                }
+                stream_completion(&model, request, request_tx)
             }
-            _ => {}
+            InferenceEvent::EmbeddingEvent(request, request_tx) => {
+                stream_embedding(&model, request, request_tx)
+            }
+            InferenceEvent::_ChatEvent => {}
         }
     }
 }
@@ -101,7 +148,10 @@ pub enum InferenceEvent {
         CompletionRequest,
         Sender<Result<StreamingResponse, InferenceError>>,
     ),
-    _EmbeddingEvent,
+    EmbeddingEvent(
+        EmbeddingRequest,
+        Sender<Result<(usize, Option<Vec<f32>>), InferenceError>>,
+    ),
     _ChatEvent,
 }
 
@@ -116,7 +166,7 @@ impl RequestQueue {
         Self { queue }
     }
     pub(crate) async fn append(&mut self, event: InferenceEvent) {
-        // TODO: result
+        // TODO: deal with result
         self.queue.send_async(event).await.unwrap_or_else(|err| {
             panic!(
                 "Can't append the event on inference queue. Err {:?}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,13 @@
 use axum::{
     routing::{get, post},
-    Router,
+    Json, Router,
 };
 use axum_prometheus::PrometheusMetricLayer;
 use axum_tracing_opentelemetry::middleware::OtelAxumLayer;
 use serde::de;
 use serde::Serialize;
 use serde::{Deserialize, Deserializer};
+use serde_json::Value;
 use std::convert::Infallible;
 use std::fmt;
 use std::marker::PhantomData;
@@ -77,6 +78,7 @@ pub async fn run_webserver(config: Config) {
     let app = Router::new()
         .route("/v1/models", get(get_models))
         .with_state(model_list)
+        .route("/v1/health", get(health_check))
         .route("/v1/completions", post(compat_completions))
         .route("/v1/completions_full", post(completions))
         .route("/v1/completions_stream", post(completions_stream))
@@ -126,4 +128,12 @@ where
     }
 
     deserializer.deserialize_any(StringOrVec(PhantomData))
+}
+
+async fn health_check() -> Json<Value> {
+    let json_response = serde_json::json!({
+        "status": "Cria is running !",
+    });
+
+    Json(json_response)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ pub async fn run_webserver(config: Config) {
 
     let (tx, rx) = flume::unbounded();
     let queue = RequestQueue::new(tx);
+
     tokio::task::spawn_blocking(move || {
         let _ = inference_loop(model, rx);
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,8 @@ use config::Config;
 use crate::{
     inferer::{inference_loop, RequestQueue},
     routes::{
+        chat::chat_completion_route,
         completions::{compat_completions, completions, completions_stream},
-        // chat::chat_completion,
         embeddings::embeddings,
         models::get_models,
     },
@@ -81,7 +81,7 @@ pub async fn run_webserver(config: Config) {
         .route("/v1/completions_full", post(completions))
         .route("/v1/completions_stream", post(completions_stream))
         .route("/v1/embeddings", post(embeddings))
-        // .route("/v1/chat/completions", post(chat_completion))
+        .route("/v1/chat/completions", post(chat_completion_route))
         .route("/metrics", get(|| async move { metric_handle.render() }))
         .with_state(queue)
         .layer(prometheus_layer)

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,6 @@ use cria::config::Config;
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
-    // let args = Args::parse();
-
     // hierarchical config. cli args override Env vars
     let config: Config = Figment::new()
         .merge(Env::prefixed("CRIA_"))

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use cli::Args;
 pub mod config;
 use cria::config::Config;
 
-#[tokio::main]
+#[tokio::main(flavor = "multi_thread")]
 async fn main() {
     // let args = Args::parse();
 
@@ -27,7 +27,7 @@ async fn main() {
 
     let subscriber = tracing_subscriber::fmt::layer().json();
 
-    let level = EnvFilter::new("debug".to_owned());
+    let level = EnvFilter::new("info".to_owned());
 
     let registry = tracing_subscriber::registry().with(subscriber).with(level);
 

--- a/src/routes/completions.rs
+++ b/src/routes/completions.rs
@@ -35,7 +35,7 @@ pub(crate) async fn completions_stream(
 ) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
     let (tx, rx) = flume::unbounded();
     let event = InferenceEvent::CompletionEvent(request, tx);
-    let _ = queue.append(event).await;
+    let _ = queue.push(event).await;
 
     let stream = stream! {
             while let Ok(streaming_response) = rx.recv_async().await{
@@ -69,7 +69,7 @@ pub(crate) async fn completions(
 ) -> Json<CompletionResponse> {
     let (tx, rx) = flume::unbounded();
     let event = InferenceEvent::CompletionEvent(request, tx);
-    let _ = queue.append(event).await;
+    let _ = queue.push(event).await;
 
     let mut response_tokens: Vec<String> = Vec::new();
     while let Ok(streaming_response) = rx.recv_async().await {

--- a/src/routes/completions.rs
+++ b/src/routes/completions.rs
@@ -12,112 +12,57 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use std::{collections::HashMap, sync::Arc};
 use uuid::Uuid;
 
+use crate::inferer::{InferenceEvent, RequestQueue, StreamingResponse};
 use crate::*;
 
 /// Basically switches between completions and completions_stream methods
 /// depending on request `stream` value
-pub(crate) async fn compat_completions(
-    model: State<Arc<dyn Model>>,
-    request: Json<CompletionRequest>,
-) -> Response {
-    tracing::debug!(
-        "Received request with streaming set to: {}",
-        &request.stream
-    );
-    if !request.stream {
-        completions(model.clone(), request).await.into_response()
-    } else {
-        completions_stream(model.clone(), request)
-            .await
-            .into_response()
-    }
-}
+// pub(crate) async fn compat_completions(
+//     model: State<Arc<dyn Model>>,
+//     request: Json<CompletionRequest>,
+// ) -> Response {
+//     tracing::debug!(
+//         "Received request with streaming set to: {}",
+//         &request.stream
+//     );
+//     if !request.stream {
+//         completions(model.clone(), request).await.into_response()
+//     } else {
+//         completions_stream(model.clone(), request)
+//             .await
+//             .into_response()
+//     }
+// }
 
 pub(crate) async fn completions_stream(
-    State(model): State<Arc<dyn Model>>,
+    State(mut queue): State<RequestQueue>,
     Json(request): Json<CompletionRequest>,
 ) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
-    let mut session: llm::InferenceSession = model.start_session(Default::default());
-    let mut response_tokens: Vec<String> = Vec::new();
-    let maximum_token_count = request.max_tokens.min(usize::MAX);
+    let (tx, rx) = flume::unbounded();
+    let event = InferenceEvent::CompletionEvent(request, tx);
+    let _ = queue.append(event).await;
 
-    let repetition_penalty_last_n = 512;
-    let sampler_args = vec![
-        format!("topk:k={}", request.top_k),
-        format!("topp:p={}", request.top_p),
-        format!(
-            "repetition:penalty={}:last_n={}",
-            request.repeat_penalty, repetition_penalty_last_n
-        ),
-        format!("temperature:temperature={}", request.temperature),
-    ];
-    let sampler = build_sampler(0, &[], &sampler_args).unwrap();
     let stream = stream! {
-    let prompt = request.prompt.into_iter().collect::<String>();
-    if !prompt.is_empty() {
-        session
-            .feed_prompt(
-                &*model,
-                llm::Prompt::Text(&prompt),
-                &mut Default::default(),
-                feed_prompt_callback::<_>(|r| match r {
-                    llm::InferenceResponse::PromptToken(_) => {
-                        Ok::<InferenceFeedback, InferenceError>(llm::InferenceFeedback::Continue)
-                    }
-                    llm::InferenceResponse::InferredToken(t) => {
-                        let _ = &response_tokens.push(t);
-                        Ok(llm::InferenceFeedback::Continue)
-                    }
-                    _ => Ok(llm::InferenceFeedback::Continue),
-                }),
-            )
-            .unwrap();
-    }
-    // After the prompt is consumed, sample tokens by repeatedly calling
-    // `infer_next_token`. We generate tokens until the model returns an
-    // EndOfText token, or we run out of space in the context window,
-    // or we reach the specified limit.
-    let mut tokens_processed = 0;
-    let mut token_utf8_buf = TokenUtf8Buffer::new();
-
-    while tokens_processed < maximum_token_count {
-        let token = match session.infer_next_token(
-            &*model,
-            &llm::InferenceParameters {
-                    sampler: sampler.clone(),
-                        },
-            &mut Default::default(),
-            &mut rand::thread_rng(),
-        ) {
-            Ok(token) => token,
-            // TODO: Send an end of stream or end
-            Err(InferenceError::EndOfText) => break,
-            // TODO: Handle actual errors
-            Err(_) => break,
-        };
-        tokens_processed += 1;
-
-        // Buffer the token until it's valid UTF-8
-        if let Some(tokens) = token_utf8_buf.push(&token) {
-            let response= CompletionResponse{
-                id: format!("cmpl-{}", Uuid::new_v4().to_string()),
-                object: "text.completion.chunk".to_string(),
-                created: SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() ,
-                model:"llama-2".to_string(),
-                choices: vec![ CompletionResponseChoices {
-                            text: tokens,
-                            index:0,
-                            logprobs: None,
-                            finish_reason: None,
-                        }
-                    ],
-                usage: None,
-            };
-            let str_response = format!(" {}",serde_json::to_string(&response).unwrap());
-            yield Ok(Event::default().data(str_response));
-            // yield Ok(Event::default().json_data(response).unwrap());
-        }
-    }
+            while let Ok(streaming_response) = rx.recv_async().await{
+                // TODO : handle error
+                if let Ok(StreamingResponse{token}) = streaming_response {
+                let response= CompletionResponse{
+                    id: format!("cmpl-{}", Uuid::new_v4().to_string()),
+                    object: "text.completion.chunk".to_string(),
+                    created: SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() ,
+                    model:"llama-2".to_string(),
+                    choices: vec![ CompletionResponseChoices {
+                                text:token,
+                                index:0,
+                                logprobs: None,
+                                finish_reason: None,
+                            }
+                        ],
+                    usage: None,
+                };
+                yield Ok(Event::default().json_data(response).unwrap());
+                }
+            }
     };
 
     Sse::new(stream).keep_alive(KeepAlive::default())
@@ -195,46 +140,46 @@ pub enum LogitBias {
 #[derive(Deserialize, Debug)]
 pub struct CompletionRequest {
     #[serde(default, deserialize_with = "string_or_seq_string")]
-    prompt: Vec<String>,
+    pub prompt: Vec<String>,
     suffix: Option<String>,
     #[serde(default = "default_max_tokens")]
-    max_tokens: usize,
+    pub max_tokens: usize,
     #[serde(default = "default_temperature")]
-    temperature: f32,
+    pub temperature: f32,
     #[serde(default = "default_top_p")]
-    top_p: f32,
+    pub top_p: f32,
     #[serde(default = "default_microstat_mode")]
-    mirostat_mode: usize,
+    pub mirostat_mode: usize,
     #[serde(default = "default_microstat_tau")]
-    mirostat_tau: f32,
+    pub mirostat_tau: f32,
     #[serde(default = "default_microstat_eta")]
-    mirostat_eta: f32,
+    pub mirostat_eta: f32,
     #[serde(default = "default_echo")]
-    echo: bool,
+    pub echo: bool,
     /// Whether to use SSE streaming with the stream terminated by a data: [DONE]
     #[serde(default = "default_stream")]
-    stream: bool,
-    stop: Option<Vec<String>>,
-    logprobs: Option<usize>,
+    pub stream: bool,
+    pub stop: Option<Vec<String>>,
+    pub logprobs: Option<usize>,
     #[serde(default = "default_presence_penalty")]
-    presence_penalty: f32,
+    pub presence_penalty: f32,
     #[serde(default = "default_frequence_penalty")]
-    frequency_penalty: f32,
-    logit_bias: Option<HashMap<String, f32>>,
+    pub frequency_penalty: f32,
+    pub logit_bias: Option<HashMap<String, f32>>,
     // llama.cpp specific parameters
     #[serde(default = "default_top_k")]
-    top_k: usize,
+    pub top_k: usize,
     #[serde(default = "default_repeat_penalty")]
-    repeat_penalty: f32,
-    logit_bias_type: Option<LogitBias>,
+    pub repeat_penalty: f32,
+    pub logit_bias_type: Option<LogitBias>,
     // ignored or currently unsupported
     // Model name to use.
-    model: Option<String>,
+    pub model: Option<String>,
     // How many completions to generate for each prompt.
-    n: Option<usize>,
+    pub n: Option<usize>,
     // Generates best_of completions server-side and returns the “best”.
-    best_of: Option<usize>, // 1
-    user: Option<String>,
+    pub best_of: Option<usize>, // 1
+    pub user: Option<String>,
 }
 
 #[derive(Serialize, Debug)]

--- a/src/routes/completions.rs
+++ b/src/routes/completions.rs
@@ -99,7 +99,7 @@ pub(crate) async fn completions_stream(
 
         // Buffer the token until it's valid UTF-8
         if let Some(tokens) = token_utf8_buf.push(&token) {
-            yield Ok(Event::default().json_data(CompletionResponse{
+            let response= CompletionResponse{
                 id: format!("cmpl-{}", Uuid::new_v4().to_string()),
                 object: "text.completion.chunk".to_string(),
                 created: SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() ,
@@ -112,7 +112,10 @@ pub(crate) async fn completions_stream(
                         }
                     ],
                 usage: None,
-            }).unwrap());
+            };
+            let str_response = format!(" {}",serde_json::to_string(&response).unwrap());
+            yield Ok(Event::default().data(str_response));
+            // yield Ok(Event::default().json_data(response).unwrap());
         }
     }
     };

--- a/src/routes/completions.rs
+++ b/src/routes/completions.rs
@@ -5,6 +5,7 @@ use axum::response::{IntoResponse, Response};
 use axum::{response::sse::Event, Json};
 use futures::Stream;
 use serde::Deserialize;
+use serde_json;
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
@@ -55,7 +56,11 @@ pub(crate) async fn completions_stream(
                         ],
                     usage: None,
                 };
-                yield Ok(Event::default().json_data(response).unwrap());
+                // Note: this is entirely for openai python client to work
+                // for some reason the python clients parses a SSE msg starting with b"data: " NOT b"data:"
+                // This different from the http spec : https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent/data
+                let data = format!(" {}",serde_json::to_string(&response).unwrap());
+                yield Ok(Event::default().data(&data));
                 }
             }
     };

--- a/src/routes/embeddings.rs
+++ b/src/routes/embeddings.rs
@@ -17,13 +17,13 @@ pub(crate) async fn embeddings(
 
     while let Ok(response) = rx.recv_async().await {
         match response {
-            Ok((response_ntokens, emb)) => {
-                ntokens += response_ntokens;
+            Ok(embd) => {
+                ntokens += embd.ntokens;
 
                 data.push(EmbeddingData {
                     object: "embedding".to_string(),
                     index: 0,
-                    embedding: emb.unwrap_or(Vec::new()),
+                    embedding: embd.embedding.unwrap_or(Vec::new()),
                 })
             }
             Err(_e) => {
@@ -51,6 +51,12 @@ pub struct EmbeddingRequest {
     #[serde(default, deserialize_with = "string_or_seq_string")]
     pub input: Vec<String>,
     pub user: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct Embedding {
+    pub embedding: Option<Vec<f32>>,
+    pub ntokens: usize,
 }
 
 #[derive(Serialize, Debug)]

--- a/src/routes/embeddings.rs
+++ b/src/routes/embeddings.rs
@@ -10,7 +10,7 @@ pub(crate) async fn embeddings(
     let (tx, rx) = flume::unbounded();
 
     let event = InferenceEvent::EmbeddingEvent(request, tx);
-    let _ = queue.append(event).await;
+    let _ = queue.push(event).await;
 
     let mut data = Vec::new();
     let mut ntokens = 0;


### PR DESCRIPTION
The previous implementations was spawning an inference session for each requests, the session where created from a clone to a `State(Arc<dyn Model>)` which was possible because Model is`Sync` but the `Session` is not. This caused GPU memory issues. In this PR, I spawned a single model and spawned a **blocking** tokio task that continuously  pulls from request  queue where incoming requests are put. For each request we start an inference session and stream results back to the caller route.
