### PR TITLE
added GitHub action to publish image

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,34 @@
+name: Upload
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build-and-publish:
+    strategy:
+      matrix:
+        include:
+          - image-name: cria
+            tag: cpu
+            dockerfile: Dockerfile-cpu
+          - image-name: cria
+            tag: gpu
+            dockerfile: Dockerfile-gpu
+    name: Build & publish Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build image
+        run: docker build . --file ${{ matrix.dockerfile }} --tag ${{ matrix.image-name }} --label "runnumber=${GITHUB_RUN_ID}"
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+      - name: Push image
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/${{ matrix.image-name }}
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          echo IMAGE_ID=$IMAGE_ID
+          docker tag ${{ matrix.image-name }} $IMAGE_ID:${{ matrix.tag }}
+          docker push $IMAGE_ID:${{ matrix.tag }}


### PR DESCRIPTION
I didn't want to create the Docker image locally for my home server setup, so I adapted this workflow from GitHub's documentation (see [documentation](https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#upgrading-a-workflow-that-accesses-a-registry-using-a-personal-access-token)) which builds the cpu and gpu images and publishes them to [GitHub Packages](https://github.com/features/packages) whenever there's a new commit on the main branch. Figured I should open a PR in case you also want it. Feel free to reject or ask for changes!

Looks like there's another workflow above the one I copied which looks cleaner, I can adapt the workflow to use that if you prefer (see [documentation](https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#publishing-a-package-using-an-action)).

You don't need to add any variable or secret to your repository for this to work.

* Example of a successful run: https://github.com/Benjamint22/cria/actions/runs/6134665643
* Example of the resulting images: https://github.com/Benjamint22/cria/pkgs/container/cria