### PR TITLE
Support for Chat streaming

### DIFF
--- a/python/openai_chat_completion.py
+++ b/python/openai_chat_completion.py
@@ -1,3 +1,5 @@
+from sys import stdout
+
 import openai
 
 openai.organization = "YOUR_ORG_ID"
@@ -8,6 +10,7 @@ openai.api_base = "http://localhost:3000/v1"
 completion = openai.ChatCompletion.create(
     model="gpt-3.5-turbo",
     max_tokens=512,
+    stream=True,
     messages=[
         {"role": "system", "content": "You are a helpful assistant."},
         {
@@ -17,4 +20,8 @@ completion = openai.ChatCompletion.create(
     ],
 )
 
-print(completion.choices[0].message)
+# Streaming
+for chunk in completion:
+    delta = chunk.choices[0].delta["content"]
+    stdout.write(delta)
+    stdout.flush()

--- a/src/inferer.rs
+++ b/src/inferer.rs
@@ -8,15 +8,14 @@ use llm::TokenUtf8Buffer;
 use llm::Tokenizer;
 use llm::{feed_prompt_callback, InferenceError, InferenceFeedback};
 
-use crate::routes::chat::chat_completion;
+use crate::routes::chat::streaming_chat_completion;
 use crate::routes::chat::ChatCompletionRequest;
-use crate::routes::chat::ChatCompletionResponse;
 use crate::routes::completions::CompletionRequest;
 use crate::routes::embeddings::Embedding;
 use crate::routes::embeddings::EmbeddingRequest;
 
 fn stream_completion(
-    model: &Box<dyn Model>,
+    model: &dyn Model,
     request: CompletionRequest,
     request_tx: Sender<Result<StreamingResponse, InferenceError>>,
 ) {
@@ -41,7 +40,7 @@ fn stream_completion(
     if !prompt.is_empty() {
         session
             .feed_prompt(
-                model.as_ref(),
+                model,
                 llm::Prompt::Text(&prompt),
                 &mut Default::default(),
                 feed_prompt_callback::<_>(|r| match r {
@@ -66,7 +65,7 @@ fn stream_completion(
 
     while tokens_processed < maximum_token_count {
         let token = match session.infer_next_token(
-            model.as_ref(),
+            model,
             &llm::InferenceParameters {
                 sampler: sampler.clone(),
             },
@@ -97,7 +96,7 @@ fn stream_completion(
 }
 
 fn embed_string(
-    model: &Box<dyn Model>,
+    model: &dyn Model,
     session: &mut InferenceSession,
     vocab: &Tokenizer,
     query: &str,
@@ -122,7 +121,7 @@ fn embed_string(
 }
 
 fn stream_embedding(
-    model: &Box<dyn Model>,
+    model: &dyn Model,
     request: EmbeddingRequest,
     request_tx: Sender<Result<Embedding, InferenceError>>,
 ) {
@@ -130,8 +129,8 @@ fn stream_embedding(
     let vocab = model.tokenizer();
 
     for input in request.input {
-        let embd = embed_string(&model, &mut session, &vocab, &input);
-        let _res = request_tx
+        let embd = embed_string(model, &mut session, vocab, &input);
+        request_tx
             .send_timeout(Ok(embd), Duration::from_millis(10))
             .unwrap();
     }
@@ -143,13 +142,13 @@ pub fn inference_loop(model: Box<dyn Model>, rx_queue: Receiver<InferenceEvent>)
     while let Ok(inference_request) = rx_queue.recv() {
         match inference_request {
             InferenceEvent::CompletionEvent(request, request_tx) => {
-                stream_completion(&model, request, request_tx)
+                stream_completion(model.as_ref(), request, request_tx)
             }
             InferenceEvent::EmbeddingEvent(request, request_tx) => {
-                stream_embedding(&model, request, request_tx)
+                stream_embedding(model.as_ref(), request, request_tx)
             }
             InferenceEvent::ChatEvent(request, request_tx) => {
-                chat_completion(&model, request, request_tx)
+                streaming_chat_completion(model.as_ref(), request, request_tx)
             }
         }
     }
@@ -166,7 +165,7 @@ pub enum InferenceEvent {
     EmbeddingEvent(EmbeddingRequest, Sender<Result<Embedding, InferenceError>>),
     ChatEvent(
         ChatCompletionRequest,
-        Sender<Result<ChatCompletionResponse, InferenceError>>,
+        Sender<Result<StreamingResponse, InferenceError>>,
     ),
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ async fn main() {
 
     let subscriber = tracing_subscriber::fmt::layer().json();
 
-    let level = EnvFilter::new("info".to_owned());
+    let level = EnvFilter::new("info");
 
     let registry = tracing_subscriber::registry().with(subscriber).with(level);
 
@@ -39,7 +39,7 @@ async fn main() {
             .with_collector_endpoint(zipkin_endpoint)
             .install_batch(opentelemetry::runtime::Tokio)
             .expect("unable to install zipkin tracer");
-        let tracer = tracing_opentelemetry::layer().with_tracer(tracer.clone());
+        let tracer = tracing_opentelemetry::layer().with_tracer(tracer);
 
         registry.with(tracer).init();
     } else {

--- a/src/routes/completions.rs
+++ b/src/routes/completions.rs
@@ -56,9 +56,12 @@ pub(crate) async fn completions_stream(
                         ],
                     usage: None,
                 };
-                // Note: this is entirely for openai python client to work
-                // for some reason the python clients parses a SSE msg starting with b"data: " NOT b"data:"
-                // This different from the http spec : https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent/data
+                /*
+                Note: this is entirely for openai python client to work
+                for some reason the python clients parses a SSE msg starting with b"data: " NOT b"data:"
+                This different from the http spec for SSE
+                : https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent/data
+                */
                 let data = format!(" {}",serde_json::to_string(&response).unwrap());
                 yield Ok(Event::default().data(&data));
                 }


### PR DESCRIPTION
fixes #19.

Example using OpenAPI : 
```python
import openai

openai.organization = "YOUR_ORG_ID"
openai.api_key = "test"
openai.api_base = "http://localhost:3000/v1"

completion = openai.ChatCompletion.create(
    model="gpt-3.5-turbo",
    max_tokens=512,
    stream=True,
    messages=[
        {"role": "system", "content": "You are a helpful assistant."},
        {
            "role": "user",
            "content": "Hello! Can you give informations about morocco ? ",
        },
    ],
)

# Streaming
for chunk in completion:
    print(chunk.choices[0].delta)

```

Result 

```bash
{
  "role": "assistant",
  "content": " Of"
}
{
  "role": "assistant",
  "content": " course"
}
{
  "role": "assistant",
  "content": ","
}
{
  "role": "assistant",
  "content": " I"
}
{
  "role": "assistant",
  "content": "'"
}
{
  "role": "assistant",
  "content": "d"
}
{
  "role": "assistant",
  "content": " be"
}
...
```
